### PR TITLE
Fixed emoji_word

### DIFF
--- a/bot_logic.rb
+++ b/bot_logic.rb
@@ -165,5 +165,5 @@ def random_user
 end
 
 def emoji_word word
-    word.gsub /(\w)/, ":\1\1:"
+    word.gsub /(\w)/, ':\1\1:'
 end


### PR DESCRIPTION
idk what the difference between `word.gsub /(\w)/, ":\1\1:"` and `word.gsub /(\w)/, ':\1\1:'` is, but there is a difference.
