### PR TITLE
Added last.fm support

### DIFF
--- a/bot_logic.rb
+++ b/bot_logic.rb
@@ -1,4 +1,4 @@
-# coding: utf-8
+  # coding: utf-8
 # -*- coding: utf-8 -*-
 require 'sinatra/base'
 require 'net/http'
@@ -70,7 +70,7 @@ class BotLogic < Sinatra::Base
 
     @current_channel = channel
     @current_user_name = user_name
-    
+
     code = params[:text]
 
     # #YOLO dawg
@@ -90,6 +90,14 @@ class BotLogic < Sinatra::Base
     Chat.new(channel).chat_out(output)
   end
 
+  post('/lastfm') do
+    puts "Processing /lastfm command"
+    puts "Params: ", params
+
+    output = LastfmLogic.process(params)
+    break output if output
+  end
+
   post('/lenny') do
     puts "Processing /lenny command"
     puts "Params: ", params
@@ -100,6 +108,8 @@ class BotLogic < Sinatra::Base
 
   run! if app_file == $0
 end
+
+
 
 def count_to_lenny(count, report_width, max_bar)
   lenny_full = '( ͡° ͜ʖ ͡°)'

--- a/bot_logic.rb
+++ b/bot_logic.rb
@@ -109,8 +109,6 @@ class BotLogic < Sinatra::Base
   run! if app_file == $0
 end
 
-
-
 def count_to_lenny(count, report_width, max_bar)
   lenny_full = '( ͡° ͜ʖ ͡°)'
   lenny_2_3 = '( ͡° ͜ʖ'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,4 +53,13 @@ ActiveRecord::Schema.define(version: 20160317225850) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "last_fm", force: :cascade do |t|
+    t.string   "user_id"
+    t.string   "name"
+    t.string   "country"
+    t.integer  "playcount"
+  end
+
+  #I'm gonna do some garbage with relational play counts and stuff so I can have similarity rankings
+
 end

--- a/lastfm_logic.rb
+++ b/lastfm_logic.rb
@@ -8,7 +8,7 @@ require 'resolv-replace'
 require './chat'
 require './user_privs'
 
-LASTFM_API_KEY = ENV['GIFME_API_KEY']
+LASTFM_API_KEY = ENV['LASTFM_API_KEY']
 
 class LastfmLogic
   def self.process(params)

--- a/lastfm_logic.rb
+++ b/lastfm_logic.rb
@@ -1,0 +1,106 @@
+# coding: utf-8
+# -*- coding: utf-8 -*-
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'resolv-replace'
+require './chat'
+require './user_privs'
+
+LASTFM_API_KEY = ENV['GIFME_API_KEY']
+
+class LastfmLogic
+  def self.process(params)
+
+    channel = params[:channel_id]
+    channel_name = params[:channel_name]
+    user_name = params[:user_name]
+    user_id = params[:user_id]
+    power_user, admin_user = UserPrivilege.user_privs(user_id)
+    command = params[:command]
+    terms = params[:text]
+
+    if terms.match(/\w+,\w+/)
+      user_string1 = terms.match(/(\w+,)/)
+      user_string2 = terms.match(/\w+, (\w+)/)
+
+      new_command = RunCommand.new user_id: user_id, user_name: user_name, command: command
+      new_command.save
+      begin
+        lastfm_search_compare(user_string1, user_string2)
+      rescue Exception => e
+        return e.message + "terms used: '#{terms}'"
+      end
+    else
+      #Get user recent track
+      new_command = RunCommand.new user_id: user_id, user_name: user_name, command: command
+      new_command.save
+
+      begin
+        lastfm_search_recent(terms)
+      rescue Exception => e
+        return e.message + "terms used: '#{terms}'"
+      end
+    end
+  end
+
+  def self.lastfm_search_recent(user_string)
+    ### DO EXTERNAL REQUEST ###
+    uri = URI.parse("http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=#{user_string}&api_key=#{LASTFM_API_KEY}&format=json&limit=1")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = false
+    request = Net::HTTP::Get.new(uri)
+    response = http.request(request)
+    ###
+
+    results = JSON.parse response.body
+
+    if results['error']
+      raise "Something went terribly, terribly wrong and you shouldn't blame Alpaca for sure"
+    end
+
+    track = results['recenttracks']['track'][0]
+    if !track
+      raise "You haven't listened to any tracks on last.fm you dumbass. Connect your spotify."
+    end
+
+    #Gets dat song info
+    artist = track['artist']['#text']
+    name = track['name']
+    album = track['album']['#text']
+    image = track['image'][2] #selects the medium size
+
+    puts "_#{user_name} last listened to _#{name}_ by #{artist} on the album _#{album}_: #{image}"
+  end
+
+  def self.lastfm_search_compare(user_string1, user_string2)
+    ### DO BOTH EXTERNAL REQUESTS ###
+    uri1 = URI.parse("http://ws.audioscrobbler.com/2.0/?method=user.gettopartists&user=#{user_string1}&api_key=#{LASTFM_API_KEY}&format=json&limit=100")
+    http1 = Net::HTTP.new(uri1.host, uri1.port)
+    http1.use_ssl = false
+    request1 = Net::HTTP::Get.new(uri1)
+    response1 = http.request(request1)
+
+    uri2 = URI.parse("http://ws.audioscrobbler.com/2.0/?method=user.gettopartists&user=#{user_string2}&api_key=#{LASTFM_API_KEY}&format=json&limit=100")
+    http2 = Net::HTTP.new(uri2.host, uri2.port)
+    http2.use_ssl = false
+    request2 = Net::HTTP::Get.new(uri2)
+    response2 = http.request(request2)
+    ###
+
+    results1 = JSON.parse response1.body
+    results2 = JSON.parse response2.body
+
+    if results1['error'] || results2['error']
+      raise "Something went terribly, terribly wrong and you shouldn't blame Alpaca for sure"
+    end
+
+    union = results1['topartists']['artist'] & results2['topartists']['artist']
+    size_of_union = union.size
+    size_of_large = [results1['topartists']['artist'].size, results2['topartists']['artist']].max
+    percentage = size_of_union / size_of_large
+
+    puts "_#{user_string1} and #{user_string2} have a #{percentage} artist overlap. Top shared artists: [#{union[0]}, #{union[1]}, #{union[2]} ]"
+  end
+end


### PR DESCRIPTION
This adds support for requests to the last.fm api, which will allow you to show what track you scrobbled last.

This command is accessed via the command `/lastfm [user1]`

While the framework for `/lastfm [user1], [user2]` is included, without a db to store the `@username` of users, you have to remember the username of the people in a slack channel. Once relational db's are working I can make this much more robust.